### PR TITLE
Fix for ORM compatibility on mail_form

### DIFF
--- a/lib/mail_form/shim.rb
+++ b/lib/mail_form/shim.rb
@@ -29,15 +29,6 @@ module MailForm
       end unless params.blank?
     end
 
-    # Returns a hash of attributes, according to the attributes existent in
-    # self.class.mail_attributes.
-    def attributes
-      self.class.mail_attributes.inject({}) do |hash, attr|
-        hash[attr.to_s] = send(attr)
-        hash
-      end
-    end
-
     # Always return true so when using form_for, the default method will be post.
     def new_record?
       true

--- a/lib/mail_form/views/mail_form/contact.erb
+++ b/lib/mail_form/views/mail_form/contact.erb
@@ -1,6 +1,6 @@
 <h4 style="text-decoration:underline"><%= message.subject %></h4>
 
-<% @resource.attributes.each do |attribute, value|
+<% @resource.mail_form_attributes.each do |attribute, value|
   next if value.blank? %>
 
   <p><b><%= @resource.class.human_attribute_name(attribute) %>:</b>


### PR DESCRIPTION
Hi Guys,

I found that the problem behind http://github.com/plataformatec/mail_form/issues#issue/4 was that active_record attribute methods were getting clobbered on line 71 of delivery.rb

```
attr_accessor *(accessors - instance_methods.map(&:to_sym))
```

I did something like this:

```
columns_methods = self.respond_to?(:column_names) ? column_names.map(&:to_sym) : []
attr_accessor *(accessors - instance_methods.map(&:to_sym) - columns_methods)
```

I was not able to figure out how to get a list of attribute_names from the class in an ORM neutral way (I seem to remember that worked in Rails 2).  So  I ended up using column_names instead.  Any better suggestions?

Additionally, the email template was using @resource.attributes to print the mail attributes. But this would print all attributes when using active_record regardless of if the user had wanted them in the email.  And redefining attributes method seemed like a bad idea going forward.

Peter
