### PR TITLE
Replace the email regexp in the readme with a better example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ if you want to make a contact form just the following lines are needed (includin
 
   class ContactForm < MailForm::Base
     attribute :name,      :validate => true
-    attribute :email,     :validate => /[^@]+@[^\.]+\.[\w\.\-]+/
+    attribute :email,     :validate => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
     attribute :file,      :attachment => true
 
     attribute :message
@@ -50,12 +50,12 @@ as ActiveModel::Validation, ActiveModel::Translation and ActiveModel::Naming.
 This bring I18n, error messages, validations and attributes handling like in
 ActiveRecord to MailForm, so MailForm can be used in your controllers and form builders without extra tweaks. This also means that instead of the following:
 
-  attribute :email, :validate => /[^@]+@[^\.]+\.[\w\.\-]+/
+  attribute :email, :validate => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
 
 You could actually do this:
 
   attribute :email
-  validates_format_of :email, :with => /[^@]+@[^\.]+\.[\w\.\-]+/
+  validates_format_of :email, :with => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
 
 Choose the one which pleases you the most. For more information on the API, please
 continue reading below.
@@ -120,7 +120,7 @@ Examples:
 
    class ContactForm < MailForm::Base
      attributes :name,  :validate => true
-     attributes :email, :validate => /[^@]+@[^\.]+\.[\w\.\-]+/
+     attributes :email, :validate => /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i
      attributes :type,  :validate => ["General", "Interface bug"]
      attributes :message
      attributes :screenshot, :attachment => true, :validate => :interface_bug?


### PR DESCRIPTION
The example email regular expression in the readme isn't very good.

As the example validation will probably get used by a large number of people, this commit replaces the current regexp with the default from Devise.
