### PR TITLE
Fix: handle multiple attachments file

### DIFF
--- a/lib/mail_form/notifier.rb
+++ b/lib/mail_form/notifier.rb
@@ -12,8 +12,8 @@ module MailForm
 
       resource.class.mail_attachments.each do |attribute|
         value = resource.send(attribute)
-        next unless value.respond_to?(:read)
-        attachments[value.original_filename] = value.read
+        handle_multiple_attachments value
+        add_attachment value
       end
 
       headers = resource.headers
@@ -21,5 +21,18 @@ module MailForm
       headers[:subject] ||= resource.class.model_name.human
       mail(headers)
     end
+
+    private 
+      def add_attachment(attch)
+        return unless attch.respond_to?(:read)
+        attachments[attch.original_filename] = attch.read
+      end
+
+      def handle_multiple_attachments(attchs) 
+        return unless attchs.respond_to?('each')
+        attchs.each do |attch|
+          add_attachment attch
+        end
+      end
   end
 end


### PR DESCRIPTION
Hi :wave:,

I'm currently using mail_form in a small project. In my use case, I have to handle multiple attachments in email. When I use your current last release of the code, multiple attachments are not being send. If I use only on attachment, everything works fine. 

As I investigate,I found out that when multiple attachments file are use, the send method respond with an array of elements ```ActionDispatch::Http::UploadedFile```. To handle this use case I made a fork of your projects and make small change in the deliver file. It seems to work as expected in Rails 6.1.4.1 with Ruby 3.0.0. 

To be honest, I completely understand if this use case doesn't interested you and can stay with my current change in my own repo. I'm also a full beginner on the RoR frameworks and Ruby development and open to any discussion to improve the code I just propose to you. 

Nice Day to everyone,
Thanks :heart: 