### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
         exclude:
           - ruby: 2.5
             gemfile: gemfiles/Gemfile-rails-main
@@ -29,6 +29,12 @@ jobs:
             gemfile: gemfiles/Gemfile-rails-5-2
           - ruby: 3.0
             gemfile: gemfiles/Gemfile-rails-5-2
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-5-2
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-6-0
+          - ruby: 3.1
+            gemfile: gemfiles/Gemfile-rails-6-1
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Add support for Rails 7.0 rc (no changes required)
+* Add support for Rails 7.0 (no changes required)
 
 # 1.9.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,5 @@ gem 'rake'
 # https://github.com/rdoc/rdoc/blob/e02728fdf440012ace74b62b00b4f4954d2f91c3/History.rdoc#430--2016-11-04
 gem 'rdoc', ">= 4.3"
 
-gem 'actionmailer', '~> 7.0.0.rc1'
-gem 'activemodel', '~> 7.0.0.rc1'
+gem 'actionmailer', '~> 7.0.0'
+gem 'activemodel', '~> 7.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,32 +8,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (7.0.0.rc1)
-      actionpack (= 7.0.0.rc1)
-      actionview (= 7.0.0.rc1)
-      activejob (= 7.0.0.rc1)
-      activesupport (= 7.0.0.rc1)
+    actionmailer (7.0.2.2)
+      actionpack (= 7.0.2.2)
+      actionview (= 7.0.2.2)
+      activejob (= 7.0.2.2)
+      activesupport (= 7.0.2.2)
       mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
       rails-dom-testing (~> 2.0)
-    actionpack (7.0.0.rc1)
-      actionview (= 7.0.0.rc1)
-      activesupport (= 7.0.0.rc1)
+    actionpack (7.0.2.2)
+      actionview (= 7.0.2.2)
+      activesupport (= 7.0.2.2)
       rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.0.rc1)
-      activesupport (= 7.0.0.rc1)
+    actionview (7.0.2.2)
+      activesupport (= 7.0.2.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.0.rc1)
-      activesupport (= 7.0.0.rc1)
+    activejob (7.0.2.2)
+      activesupport (= 7.0.2.2)
       globalid (>= 0.3.6)
-    activemodel (7.0.0.rc1)
-      activesupport (= 7.0.0.rc1)
-    activesupport (7.0.0.rc1)
+    activemodel (7.0.2.2)
+      activesupport (= 7.0.2.2)
+    activesupport (7.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -41,22 +44,41 @@ GEM
     builder (3.2.4)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    digest (3.1.0)
     erubi (1.10.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    loofah (2.12.0)
+    io-wait (0.2.1)
+    loofah (2.14.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
-    minitest (5.14.4)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    mini_portile2 (2.8.0)
+    minitest (5.15.0)
+    net-imap (0.2.3)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.1)
+      digest
+      net-protocol
+      timeout
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    psych (4.0.3)
+      stringio
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -67,7 +89,11 @@ GEM
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
     rake (13.0.6)
-    rdoc (6.3.3)
+    rdoc (6.4.0)
+      psych (>= 4.0.0)
+    stringio (3.0.1)
+    strscan (3.0.1)
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
 
@@ -75,8 +101,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (~> 7.0.0.rc1)
-  activemodel (~> 7.0.0.rc1)
+  actionmailer (~> 7.0.0)
+  activemodel (~> 7.0.0)
   mail_form!
   rake
   rdoc (>= 4.3)


### PR DESCRIPTION
Adds Ruby 3.1 to the CI matrix. In addition to the minimal change to the CI configuration, the following additional changes are made to support the addition:

1. The version of the Rails in Gemfile and Gemfile.lock is updated from 7.0.0.rc1 to 7.0.2.2
2. Additional gem versions in Gemfile.lock are updated via bundle update
3. The CHANGELOG.md is updated to reflect the above
4. The 3.0 in the CI configuration is quoted, so that it properly resolves to a 3.0.x version. An unquoted 3.0 will be truncated to 3, causing it to load the latest Ruby 3 - at this time 3.1.1. To ensure a 3.0.x version is loaded we quote the 3.0.